### PR TITLE
ISSUE-25 - Fix subscription with engine passed as parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Released]
 
+- [0.8.x]
+  - [0.8.1](./changelogs/0.8.1.md) - 2019-06-19
+  - [0.8.0](./changelogs/0.8.0.md) - 2019-06-17
 - [0.7.x]
   - [0.7.0](./changelogs/0.7.0.md) - 2019-05-21
 - [0.6.x]

--- a/changelogs/0.8.1.md
+++ b/changelogs/0.8.1.md
@@ -1,0 +1,24 @@
+# [0.8.1] - 2019-06-19
+
+## Fixed
+
+- Fixed the issue [#25](https://github.com/tartiflette/tartiflette-aiohttp/issues/25) thrown by @arjandepooter
+
+It was impossible to execute subscription with this piece of code.
+
+```python
+def run():
+    app = web.Application()
+
+    engine: Engine = create_engine(
+       ...
+    )
+
+    web.run_app(
+        register_graphql_handlers(
+            app=app,
+            engine=engine,
+            subscription_ws_endpoint="/ws",
+        )
+    )
+```

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ _TEST_REQUIRE = [
     "isort==4.3.4",
 ]
 
-_VERSION = "0.8.0"
+_VERSION = "0.8.1"
 
 _PACKAGES = find_packages(exclude=["tests*"])
 

--- a/tartiflette_aiohttp/__init__.py
+++ b/tartiflette_aiohttp/__init__.py
@@ -33,15 +33,13 @@ def validate_and_compute_graphiql_option(
 
 
 def _set_subscription_ws_handler(
-    app: "Application",
-    subscription_ws_endpoint: Optional[str],
-    engine: "Engine",
+    app: "Application", subscription_ws_endpoint: Optional[str]
 ) -> None:
     if not subscription_ws_endpoint:
         return
 
     app.router.add_route(
-        "GET", subscription_ws_endpoint, AIOHTTPSubscriptionHandler(engine)
+        "GET", subscription_ws_endpoint, AIOHTTPSubscriptionHandler(app)
     )
 
 
@@ -178,7 +176,7 @@ def register_graphql_handlers(
         except AttributeError:
             raise Exception("Unsupported < %s > http method" % method)
 
-    _set_subscription_ws_handler(app, subscription_ws_endpoint, engine)
+    _set_subscription_ws_handler(app, subscription_ws_endpoint)
 
     _set_graphiql_handler(
         app,

--- a/tartiflette_aiohttp/_subscription_ws_handler.py
+++ b/tartiflette_aiohttp/_subscription_ws_handler.py
@@ -77,8 +77,8 @@ class AIOHTTPConnectionContext:
 
 
 class AIOHTTPSubscriptionHandler:
-    def __init__(self, engine: "Engine") -> None:
-        self._engine: "Engine" = engine
+    def __init__(self, app: "Application") -> None:
+        self._app: "Application" = app
 
     async def _send_message(
         self,
@@ -154,7 +154,7 @@ class AIOHTTPSubscriptionHandler:
         if connection_context.has_operation(operation_id):
             await self._unsubscribe(connection_context, operation_id)
 
-        iterator = self._engine.subscribe(**params)
+        iterator = self._app["ttftt_engine"].subscribe(**params)
 
         connection_context.register_operation(operation_id, iterator)
 


### PR DESCRIPTION
Fix the subscription when the engine is passed as a parameter of `register_graphql_handlers(engine=e)`

Fix #25