### PR TITLE
doc/issue-76

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 _TEST_REQUIRE = [
     "pytest==5.4.1",
     "pytest-cov==2.8.1",
-    "pytest-asyncio==0.10.0",
+    "pytest-asyncio==0.11.0",
     "pytest-aiohttp==0.3.0",
     "asynctest==0.13.0",
     "pytz",


### PR DESCRIPTION
Pull request for connection _unsubscribe implementation based on tasks rather than trying to directly close the async generator directly, to fix changes made in python 3.8.

Information to do it this way gotten from: https://bugs.python.org/issue38559

This is way outside of my wheelhouse so if someone with asyncio experience can take a look and make sure this is the correct way to proceed that'd be good.

Thanks