### PR TITLE
Allow custom context_factory to be an asynccontextmanager (tartiflette#94)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,11 @@ setup(
     ],
     keywords="api graphql protocol api rest relay tartiflette dailymotion",
     packages=_PACKAGES,
-    install_requires=["aiohttp>=3.5.4,<3.7.0", "tartiflette>=0.12.0,<2.0.0"],
+    install_requires=[
+        "aiohttp>=3.5.4,<3.7.0",
+        "async_generator;python_version=='3.6.*'",
+        "tartiflette>=0.12.0,<2.0.0",
+    ],
     tests_require=_TEST_REQUIRE,
     extras_require={"test": _TEST_REQUIRE},
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ _TEST_REQUIRE = [
     "xenon==0.7.0",
     "black==19.10b0",
     "isort==4.3.21",
+    "async_generator==1.10;python_version=='3.6.*'",
 ]
 
 _VERSION = "1.2.0"

--- a/tartiflette_aiohttp/__init__.py
+++ b/tartiflette_aiohttp/__init__.py
@@ -2,7 +2,7 @@ import json
 
 from functools import partial
 from inspect import iscoroutine
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from tartiflette import Engine
 from tartiflette_aiohttp._context_factory import default_context_factory
@@ -37,7 +37,7 @@ def validate_and_compute_graphiql_option(
 def _set_subscription_ws_handler(
     app: "Application",
     subscription_ws_endpoint: Optional[str],
-    context_factory: Callable,
+    context_factory: "AbstractAsyncContextManager",
 ) -> None:
     if not subscription_ws_endpoint:
         return
@@ -118,7 +118,7 @@ def register_graphql_handlers(
     engine_modules: Optional[
         List[Union[str, Dict[str, Union[str, Dict[str, str]]]]]
     ] = None,
-    context_factory: Optional[Callable] = None,
+    context_factory: Optional["AbstractAsyncContextManager"] = None,
 ) -> "Application":
     """Register a Tartiflette Engine to an app
 
@@ -136,12 +136,11 @@ def register_graphql_handlers(
         graphiql_enabled {bool} -- Determines whether or not we should handle a GraphiQL endpoint (default: {False})
         graphiql_options {dict} -- Customization options for the GraphiQL instance (default: {None})
         engine_modules: {Optional[List[Union[str, Dict[str, Union[str, Dict[str, str]]]]]]} -- Module to import (default:{None})
-        context_factory: {Optional[Callable]} -- coroutine function in charge of generating the context for each request (default: {None})
+        context_factory: {Optional[AbstractAsyncContextManager]} -- asynccontextmanager in charge of generating the context for each request (default: {None})
 
     Raises:
         Exception -- On bad sdl/engine parameter combinaison.
         Exception -- On unsupported HTTP Method.
-        Exception -- if `context_factory` is filled in without a coroutine function.
 
     Return:
         The app object.

--- a/tartiflette_aiohttp/__init__.py
+++ b/tartiflette_aiohttp/__init__.py
@@ -1,7 +1,7 @@
 import json
 
 from functools import partial
-from inspect import iscoroutine, iscoroutinefunction
+from inspect import iscoroutine
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from tartiflette import Engine
@@ -157,11 +157,6 @@ def register_graphql_handlers(
 
     if context_factory is None:
         context_factory = default_context_factory
-
-    if not iscoroutinefunction(context_factory):
-        raise Exception(
-            "`context_factory` parameter should be a coroutine function."
-        )
 
     context_factory = partial(context_factory, executor_context)
 

--- a/tartiflette_aiohttp/_context_factory.py
+++ b/tartiflette_aiohttp/_context_factory.py
@@ -1,8 +1,14 @@
 from typing import Any, Dict
 
+try:
+    from contextlib import asynccontextmanager  # Python 3.7+
+except ImportError:
+    from async_generator import asynccontextmanager  # Python 3.6
+
 __all__ = ("default_context_factory",)
 
 
+@asynccontextmanager
 async def default_context_factory(
     context: Dict[str, Any], req: "aiohttp.web.Request"
 ) -> Dict[str, Any]:
@@ -16,4 +22,4 @@ async def default_context_factory(
     :return: the context for the incoming request
     :rtype: Dict[str, Any]
     """
-    return {**context, "req": req}
+    yield {**context, "req": req}

--- a/tartiflette_aiohttp/_handler.py
+++ b/tartiflette_aiohttp/_handler.py
@@ -28,17 +28,6 @@ class BadRequestError(Exception):
     pass
 
 
-class NullAsyncContextManager:
-    def __init__(self, coroutine):
-        self.coroutine = coroutine
-
-    async def __aenter__(self):
-        return await self.coroutine
-
-    async def __aexit__(self, exc_type, exc, traceback):
-        pass
-
-
 def prepare_response(data):
     headers = get_response_headers()
     return web.json_response(data, headers=headers, dumps=json.dumps)
@@ -48,12 +37,6 @@ async def _handle_query(
     req, query, query_vars, operation_name, context_factory
 ):
     context_factory_mgr = context_factory(req)
-
-    # backwards compatibility with versions <= 1.2.0
-    # if context_factory is not a context manager, assume it is a coroutine function,
-    # and wrap it in a null context manager so it works with "async with" statement.
-    if not hasattr(context_factory_mgr, "__aenter__"):
-        context_factory_mgr = NullAsyncContextManager(context_factory_mgr)
 
     async with context_factory_mgr as context:
         try:

--- a/tests/integration/test_handlers.py
+++ b/tests/integration/test_handlers.py
@@ -1,5 +1,5 @@
 try:
-    from contextlib import asynccontextmanager  # Python 3.7
+    from contextlib import asynccontextmanager  # Python 3.7+
 except ImportError:
     from async_generator import asynccontextmanager  # Python 3.6
 from functools import partial


### PR DESCRIPTION
This adds support for context_factory to be defined as an asynccontextmanager, which allows for both setup and teardown of any data in the context.

~~To maintain backwards compatibility, context_factory is also still allowed to be defined as a coroutinefunction.~~ Backwards compatibility removed as it was not deemed necessary. The context_factory can now only be an asynccontextmanager, and default_context_factory has been updated accordingly.

Closes #94 