### PR TITLE
Add a way to provide your own response_formatter.

### DIFF
--- a/tests/functional/test_register_app.py
+++ b/tests/functional/test_register_app.py
@@ -6,6 +6,7 @@ from aiohttp import web
 
 from tartiflette import Engine, Resolver, create_engine
 from tartiflette_aiohttp import register_graphql_handlers
+from tartiflette_aiohttp._handler import prepare_response
 
 
 async def test_awaitable_engine(aiohttp_client, loop):
@@ -93,3 +94,53 @@ async def test_engine_composition(aiohttp_client, loop):
     assert resp.status == 200
     result = await resp.json()
     assert result == {"data": {"bob": {"name": "a", "surname": "b"}}}
+
+
+async def test_register_response_formatter(loop):
+    @Resolver("Query.bob", schema_name="test_register_response_formatter")
+    async def resolver_lol(*args, **kwargs):
+        return {"name": "a", "surname": "b"}
+
+    class myEngine(Engine):
+        def __init__(self):
+            super().__init__()
+
+        async def cook(self, *args, **kwargs):
+            await super().cook(*args, **kwargs)
+
+    def response_formatter():
+        pass
+
+    app = register_graphql_handlers(
+        app=web.Application(),
+        engine=myEngine(),
+        engine_sdl="""type Query { bob: Ninja } type Ninja { name: String surname: String }""",
+        engine_schema_name="test_register_response_formatter",
+        response_formatter=response_formatter,
+    )
+
+    assert app["response_formatter"] is response_formatter
+
+
+async def test_register_response_formatter_default(loop):
+    @Resolver(
+        "Query.bob", schema_name="test_register_response_formatter_default"
+    )
+    async def resolver_lol(*args, **kwargs):
+        return {"name": "a", "surname": "b"}
+
+    class myEngine(Engine):
+        def __init__(self):
+            super().__init__()
+
+        async def cook(self, *args, **kwargs):
+            await super().cook(*args, **kwargs)
+
+    app = register_graphql_handlers(
+        app=web.Application(),
+        engine=myEngine(),
+        engine_sdl="""type Query { bob: Ninja } type Ninja { name: String surname: String }""",
+        engine_schema_name="test_register_response_formatter_default",
+    )
+
+    assert app["response_formatter"] is prepare_response


### PR DESCRIPTION
This PR enable use to register callable looking like:
```python
def a_method(req: aiohttp.web.Request, data: Dict[str, Any], ctx: Dict[str, Any]) -> aiohttp.web.Response:
     pass
```

This is done via the `register_graphql_handler(..., response_formatter= a_method)`.

