### PR TITLE
docs: Fix a few typos

### DIFF
--- a/changelogs/1.1.1.md
+++ b/changelogs/1.1.1.md
@@ -2,7 +2,7 @@
 
 ## Changed
 
-- Github actions worflow. There is now only one.
+- Github actions workflow. There is now only one.
 - xenon updated to 0.7.0
 - pytest updated to 5.2.1
 - pytest-cov updated to 2.8.1

--- a/changelogs/1.3.0.md
+++ b/changelogs/1.3.0.md
@@ -23,4 +23,4 @@ This is done via the `register_graphql_handler(..., response_formatter= a_method
 
 ## Fixed
 
-* [ISSUE-76](https://github.com/tartiflette/tartiflette-aiohttp/issues/76) - Fix subscrition handling of client disconnection - Thanks [@daveoconnor](https://github.com/daveoconnor)
+* [ISSUE-76](https://github.com/tartiflette/tartiflette-aiohttp/issues/76) - Fix subscription handling of client disconnection - Thanks [@daveoconnor](https://github.com/daveoconnor)


### PR DESCRIPTION
There are small typos in:
- changelogs/1.1.1.md
- changelogs/1.3.0.md

Fixes:
- Should read `workflow` rather than `worflow`.
- Should read `subscription` rather than `subscrition`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md